### PR TITLE
Adds json and the requests module.

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -41,9 +41,9 @@ class CustomerIO(object):
         payload = json.dumps(data)
 
         if self.port == 443:
-            full_url = "https://%s/%s" % (self.host, query_string)
+            full_url = "https://%s%s" % (self.host, query_string)
         else:
-            full_url = "https://%s/%s:%i" % (self.host, query_string, self.port)
+            full_url = "https://%s:%i%s" % (self.host, self.port, query_string)
 
         headers = {
             'Content-Type': 'application/json',


### PR DESCRIPTION
I tried to keep the function interfaces the same, but since I'm adding the requests module, I bumped up the version number.

Upside: requests module is much cleaner and easier to use than what Python has built in.

Downside: this will break for existing users of this module, until they also install requests (available on pip).

I wanted to put this out there as an alternative, since I made this before I realized requests wasn't in the standard library yet. But I will work on a similar pull request with the standard lib stuff again next.
