### PR TITLE
Adds json without requests module

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -4,7 +4,7 @@ import base64
 import urllib
 from httplib import HTTPSConnection
 
-VERSION = (0, 1, 2, 'final', 0)
+VERSION = (0, 1, 3, 'final', 0)
 
 def get_version():
     version = '%s.%s' % (VERSION[0], VERSION[1])
@@ -21,13 +21,6 @@ def get_version():
 class CustomerIOException(Exception):
     pass
 
-class ObjectEncoder(json.JSONEncoder):
-    def default(self, obj):
-        try:
-            return JSONEncoder.default(obj, **kwargs)
-        except:
-            return str(obj)
-
 class CustomerIO(object):
     def __init__(self, site_id=None, api_key=None, host=None, port=None, url_prefix=None):
         self.site_id = site_id
@@ -43,7 +36,7 @@ class CustomerIO(object):
         return '%s/customers/%s/events' % (self.url_prefix, customer_id)
 
     def send_request(self, method, query_string, data):
-        data = json.dumps(data, cls=ObjectEncoder)
+        data = json.dumps(data)
         http = HTTPSConnection(self.host, self.port)
         basic_auth = base64.encodestring('%s:%s' % (self.site_id, self.api_key)).replace('\n', '')
         headers = {
@@ -54,7 +47,7 @@ class CustomerIO(object):
         http.request(method, query_string, data, headers)
         result_status = http.getresponse().status
         if result_status != 200:
-            raise CustomerIOException('%s: %s %s' % (result_status, query_string, data_string))
+            raise CustomerIOException('%s: %s %s' % (result_status, query_string, data))
 
     def identify(self, **kwargs):
         url = self.get_customer_query_string(kwargs['id'])
@@ -62,9 +55,8 @@ class CustomerIO(object):
 
     def track(self, customer_id, name, **data):
         url = self.get_event_query_string(customer_id)
-        encoded_data = {
+        post_data = {
             'name': name,
+            'data': data,
         }
-        for key, value in data.iteritems():
-            encoded_data['data[%s]' % key] = value
-        self.send_request('POST', url, encoded_data)
+        self.send_request('POST', url, post_data)


### PR DESCRIPTION
This is basically a small fix on top of https://github.com/customerio/customerio-python/pull/3

In his pull request, ryanwitt opted for Ruby's querystring array syntax. I'm not sure why, since full json has strictly more utility, so I opted for the full json. In any case, the code that pull request, as of now, does not work, and as of now the code in this one does, at least for me. This code specifically works:

```
cio.track(customer_id="test_123", name="event_name", lol=['a', 'b', {3:'c'}])
```

I also took out the ObjectEncoder thing in ryan's pull request, I'm not sure what that was aiming to do. Hopefully it wasn't something that I didn't account for. Though, it looks like it had a name error in it anyway, so I don't know if it ever ran? I commented on that particular commit (made by EButlerV in this case) asking if there was some important reason for it.
