### PR TITLE
allow for backfilling of events by specifying timestamp

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -53,10 +53,13 @@ class CustomerIO(object):
         url = self.get_customer_query_string(kwargs['id'])
         self.send_request('PUT', url, kwargs)
 
-    def track(self, customer_id, name, **data):
+    def track(self, customer_id, name, timestamp=None, **data):
         url = self.get_event_query_string(customer_id)
         post_data = {
             'name': name,
             'data': data,
         }
+        if timestamp:
+            #TODO handle datetime objects
+            post_data['timestamp'] = timestamp
         self.send_request('POST', url, post_data)


### PR DESCRIPTION
In the docs you can specify a timestamp for events for the purposes of backfilling:
http://customer.io/docs/importing-old-data.html

The previous code base would take a timestamp argument and put it in the data portion of the event instead of at the toplevel. This change prevents using both timestamp and data['timestamp']
