### PR TITLE
Use ints for Python 3 timestamps, too

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -154,6 +154,6 @@ Last caught exception -- {klass}: {message}
 
     def _datetime_to_timestamp(self, dt):
         if USE_PY3_TIMESTAMPS:
-            return dt.replace(tzinfo=timezone.utc).timestamp()
+            return int(dt.replace(tzinfo=timezone.utc).timestamp())
         else:
             return int(time.mktime(dt.timetuple()))


### PR DESCRIPTION
This casts Python 3 timestamps to ints so that they work as expected in `created_at` and other datetime fields.