### PR TITLE
move versioning code to setup.py

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -13,19 +13,6 @@ try:
 except ImportError:
     USE_PY3_TIMESTAMPS = False
 
-VERSION = (0, 2, 0, 'final', 0)
-
-def get_version():
-    version = '%s.%s' % (VERSION[0], VERSION[1])
-    if VERSION[2]:
-        version = '%s.%s' % (version, VERSION[2])
-    if VERSION[3:] == ('alpha', 0):
-        version = '%s pre-alpha' % version
-    else:
-        if VERSION[3] != 'final':
-            version = '%s %s %s' % (version, VERSION[3], VERSION[4])
-    return version
-
 warnings.simplefilter("default")
 
 class CustomerIOException(Exception):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,17 @@
 from setuptools import find_packages, setup
 
-from customerio import get_version
+VERSION = (0, 2, 0, 'final', 0)
 
+def get_version():
+    version = '%s.%s' % (VERSION[0], VERSION[1])
+    if VERSION[2]:
+        version = '%s.%s' % (version, VERSION[2])
+    if VERSION[3:] == ('alpha', 0):
+        version = '%s pre-alpha' % version
+    else:
+        if VERSION[3] != 'final':
+            version = '%s %s %s' % (version, VERSION[3], VERSION[4])
+    return version
 
 setup(
     name="customerio",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,5 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires=['requests>=2.5'],
     test_suite="tests",
 )


### PR DESCRIPTION
having `setup.py` import the main project causes the project's dependencies (notably `requests`) to be installed _before_ this is installed.

 Since the version code is only being used in the setup file, moving it there will allow a cleaner install