### PR TITLE
Remove overbroad warning config

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -13,7 +13,6 @@ try:
 except ImportError:
     USE_PY3_TIMESTAMPS = False
 
-warnings.simplefilter("default")
 
 class CustomerIOException(Exception):
     pass


### PR DESCRIPTION
By setting a simple filter that catches all warnings, importing this library can blow away other warning configs.