### PR TITLE
Fix for NaN not being JSON compliant.

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -2,6 +2,7 @@ from __future__ import division
 from datetime import datetime
 import time
 import warnings
+import math
 
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -138,6 +139,8 @@ Last caught exception -- {klass}: {message}
         for k, v in data.items():
             if isinstance(v, datetime):
                 data[k] = self._datetime_to_timestamp(v)
+            if isinstance(v, float) and math.isnan(v):
+                data[k] = None
         return data
 
     def _datetime_to_timestamp(self, dt):


### PR DESCRIPTION
#Updates the `_sanitize` method to replace all instances of `math.nan` by None.

Fix for #35 

Reason: Bug where if one of the arguments of the `identify` method has value `math.nan`, no exception is given by the API (ie: returns 200), however, the customer is not saved/updated.

Example:

```
import math
from customerio import CustomerIO

cio = CustomerIO(site_id, api_key)
data = {'id': 1, 'email': 'test@test.test', 'value': math.nan}
cio.identify(**data}
```

Expected: a user with email `test@test.test` should appear in the interface.
Actual: code runs fine, nothing happens in interface 