### PR TITLE
Remove logging of warnings

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -14,8 +14,6 @@ try:
 except ImportError:
     USE_PY3_TIMESTAMPS = False
 
-warnings.simplefilter("default")
-
 class CustomerIOException(Exception):
     pass
 


### PR DESCRIPTION
It seems like the library is configuring the warning log settings. Is that intentional?