### PR TITLE
Add support for suppression APIs

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -164,9 +164,15 @@ Last caught exception -- {klass}: {message}
         self.send_request('DELETE', delete_url, {})
 
     def suppress(self, customer_id):
+        if not customer_id:
+            raise CustomerIOException("customer_id cannot be blank in suppress")
+
         self.send_request('POST', '{base}/customers/{id}/suppress'.format(base=self.base_url, id=customer_id), {})
     
     def unsuppress(self, customer_id):
+        if not customer_id:
+            raise CustomerIOException("customer_id cannot be blank in unsuppress")
+
         self.send_request('POST', '{base}/customers/{id}/unsuppress'.format(base=self.base_url, id=customer_id), {})
 
     def _sanitize(self, data):

--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -134,6 +134,12 @@ Last caught exception -- {klass}: {message}
         url = self.get_customer_query_string(customer_id)
         self.send_request('DELETE', url, {})
 
+    def suppress(self, customer_id):
+        self.send_request('POST', '{base}/customers/{id}/suppress'.format(base=self.base_url, id=customer_id), {})
+    
+    def unsuppress(self, customer_id):
+        self.send_request('POST', '{base}/customers/{id}/unsuppress'.format(base=self.base_url, id=customer_id), {})
+
     def _sanitize(self, data):
         for k, v in data.items():
             if isinstance(v, datetime):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = (0, 2, 4, 'final', 0)
+VERSION = (0, 3, 0, 'final', 0)
 
 def get_version():
     version = '%s.%s' % (VERSION[0], VERSION[1])

--- a/tests/test_customerio.py
+++ b/tests/test_customerio.py
@@ -125,30 +125,6 @@ class TestCustomerIO(HTTPSTestCase):
         with self.assertRaises(TypeError):
             self.cio.backfill(random_attr="some_value")
 
-
-    def test_suppress_call(self):
-        self.cio.http.hooks=dict(response=partial(self._check_request, rq={
-            'method': 'POST',
-            'authorization': _basic_auth_str('siteid', 'apikey'),
-            'content_type': 'application/json',
-            'url_suffix': '/customers/1/suppress',
-            'body': {},
-        }))
-
-        self.cio.suppress(1)
-
-    def test_unsuppress_call(self):
-        self.cio.http.hooks=dict(response=partial(self._check_request, rq={
-            'method': 'POST',
-            'authorization': _basic_auth_str('siteid', 'apikey'),
-            'content_type': 'application/json',
-            'url_suffix': '/customers/1/unsuppress',
-            'body': {},
-        }))
-
-        self.cio.unsuppress(1)
-
-
     def test_base_url(self):
         test_cases = [
             # host, port, prefix, result
@@ -237,6 +213,32 @@ class TestCustomerIO(HTTPSTestCase):
         self.cio.delete_device(customer_id=1, device_id="device_1")
         with self.assertRaises(TypeError):
             self.cio.delete_device(random_attr="some_value")
+    
+    def test_suppress_call(self):
+        self.cio.http.hooks=dict(response=partial(self._check_request, rq={
+            'method': 'POST',
+            'authorization': _basic_auth_str('siteid', 'apikey'),
+            'content_type': 'application/json',
+            'url_suffix': '/customers/1/suppress',
+            'body': {},
+        }))
+
+        self.cio.suppress(1)
+
+        with self.assertRaises(CustomerIOException):
+            self.cio.suppress(None)
+
+    def test_unsuppress_call(self):
+        self.cio.http.hooks=dict(response=partial(self._check_request, rq={
+            'method': 'POST',
+            'authorization': _basic_auth_str('siteid', 'apikey'),
+            'content_type': 'application/json',
+            'url_suffix': '/customers/1/unsuppress',
+            'body': {},
+        }))
+
+        with self.assertRaises(CustomerIOException):
+            self.cio.unsuppress(None)
 
 
     @unittest.skipIf(sys.version_info.major > 2, "python2 specific test case")

--- a/tests/test_customerio.py
+++ b/tests/test_customerio.py
@@ -126,6 +126,29 @@ class TestCustomerIO(HTTPSTestCase):
             self.cio.backfill(random_attr="some_value")
 
 
+    def test_suppress_call(self):
+        self.cio.http.hooks=dict(response=partial(self._check_request, rq={
+            'method': 'POST',
+            'authorization': _basic_auth_str('siteid', 'apikey'),
+            'content_type': 'application/json',
+            'url_suffix': '/customers/1/suppress',
+            'body': {},
+        }))
+
+        self.cio.suppress(1)
+
+    def test_unsuppress_call(self):
+        self.cio.http.hooks=dict(response=partial(self._check_request, rq={
+            'method': 'POST',
+            'authorization': _basic_auth_str('siteid', 'apikey'),
+            'content_type': 'application/json',
+            'url_suffix': '/customers/1/unsuppress',
+            'body': {},
+        }))
+
+        self.cio.unsuppress(1)
+
+
     def test_base_url(self):
         test_cases = [
             # host, port, prefix, result


### PR DESCRIPTION
Adds handlers for the new [suppress](https://learn.customer.io/api/#apisuppress_add) and [unsuppress](https://learn.customer.io/api/#apisuppress_delete) endpoints, and associated tests