### PR TITLE
Convert date objects to timestamp when sanitizing data

### DIFF
--- a/customerio/client_base.py
+++ b/customerio/client_base.py
@@ -2,7 +2,7 @@
 Implements the base client that is used by other classes to make requests
 """
 from __future__ import division
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 import math
 
 from requests import Session
@@ -48,12 +48,18 @@ Last caught exception -- {klass}: {message}
         for k, v in data.items():
             if isinstance(v, datetime):
                 data[k] = self._datetime_to_timestamp(v)
+            if isinstance(v, date):
+                data[k] = self._date_to_timestamp(v)
             if isinstance(v, float) and math.isnan(v):
                 data[k] = None
         return data
 
     def _datetime_to_timestamp(self, dt):
         return int(dt.replace(tzinfo=timezone.utc).timestamp())
+
+    def _date_to_timestamp(self, d):
+        dt = datetime.combine(d, time=datetime.min.time())
+        return self._datetime_to_timestamp(dt)
 
     def _stringify_list(self, customer_ids):
         customer_string_ids = []

--- a/tests/test_customerio.py
+++ b/tests/test_customerio.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from functools import partial
 import json
 import sys
@@ -251,9 +251,9 @@ class TestCustomerIO(HTTPSTestCase):
 
     def test_sanitize(self):
         from datetime import timezone
-        data_in = dict(dt=datetime(2009, 2, 13, 23, 31, 30, 0, timezone.utc))
+        data_in = dict(dt=datetime(2009, 2, 13, 23, 31, 30, 0, timezone.utc), d=date(2009, 2, 14))
         data_out = self.cio._sanitize(data_in)
-        self.assertEqual(data_out, dict(dt=1234567890))
+        self.assertEqual(data_out, dict(dt=1234567890, d=1234569600))
 
     def test_ids_are_encoded_in_url(self):
         self.cio.http.hooks=dict(response=partial(self._check_request, rq={


### PR DESCRIPTION
The `_sanitize` method converts `datetime.datetime` objects to their corresponding timestamps but `datetime.date` objects are not encoded and calls to Customer.IO fail when adding `datetime.date` objects to `data`.