### PR TITLE
Add support for anonymous events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## [1.2.0]
+### Added
+- Support for anonymous events using `track_anonymous` function. 
+
 ## [1.1.0]  - March 25, 2021
 ### Added
 - Support for EU region

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Keyword arguments to backfill work the same as a call to ```cio.track```.
 
 See original REST documentation [here](http://customer.io/docs/api/rest.html#section-Track_a_custom_event)
 
+### Track an anonymous event
+
+```python
+cio.track_anonymous(anonymous_id="anon-event", name="purchased", price=23.45, product="widget")
+```
+
+An anonymous event is an event associated with a person you haven't identified. The event requires an `anonymous_id` representing the unknown person and an event `name`. When you identify a person, you can set their `anonymous_id` attribute. If [event merging](https://customer.io/docs/anonymous-events/#turn-on-merging) is turned on in your workspace, and the attribute matches the `anonymous_id` in one or more events that were logged within the last 30 days, we associate those events with the person.
+
 ### Delete a customer profile
 ```python
 cio.delete(customer_id="5")

--- a/customerio/track.py
+++ b/customerio/track.py
@@ -49,6 +49,10 @@ class CustomerIO(ClientBase):
         '''Generates an event API path'''
         return '{base}/customers/{id}/events'.format(base=self.base_url, id=self._url_encode(customer_id))
 
+    def get_events_query_string(self):
+        '''Returns the events API path'''
+        return '{base}/events'.format(base=self.base_url)
+
     def get_device_query_string(self, customer_id):
         '''Generates a device API path'''
         return '{base}/customers/{id}/devices'.format(base=self.base_url, id=self._url_encode(customer_id))
@@ -66,6 +70,18 @@ class CustomerIO(ClientBase):
             raise CustomerIOException("customer_id cannot be blank in track")
         url = self.get_event_query_string(customer_id)
         post_data = {
+            'name': name,
+            'data': self._sanitize(data),
+        }
+        self.send_request('POST', url, post_data)
+
+    def track_anonymous(self, anonymous_id, name, **data):
+        '''Track an event for a given anonymous_id'''
+        if not anonymous_id:
+            raise CustomerIOException("anonymous_id cannot be blank in track")
+        url = self.get_events_query_string()
+        post_data = {
+            'anonymous_id': anonymous_id,
             'name': name,
             'data': self._sanitize(data),
         }

--- a/tests/test_customerio.py
+++ b/tests/test_customerio.py
@@ -102,6 +102,17 @@ class TestCustomerIO(HTTPSTestCase):
             self.cio.track(random_attr="some_value")
 
 
+    def test_track_anonymous_call(self):
+        self.cio.http.hooks=dict(response=partial(self._check_request, rq={
+            'method': 'POST',
+            'authorization': _basic_auth_str('siteid', 'apikey'),
+            'content_type': 'application/json',
+            'url_suffix': '/events',
+            'body': {"data": {"email": "john@test.com"}, "name": "sign_up", "anonymous_id": 123},
+        }))
+
+        self.cio.track_anonymous(anonymous_id=123, name='sign_up', email='john@test.com')
+
     def test_pageview_call(self):
         self.cio.http.hooks=dict(response=partial(self._check_request, rq={
             'method': 'POST',


### PR DESCRIPTION
This PR adds support for sending anonymous events. These anonymous events can later be associated / identified with an existing customer.

###### Usage

```
cio = CustomerIO(…)
cio.track_anonymous(anonymous_id='123', name='sign_up', { ... })
```

We don't generate anonymous IDs. The user has to generate them and pass them to the `track_anonymous` method.

### Notes

This needs documentation, examples, and README updates before merging.