### PR TITLE
feat(gitpod): add gitpod.yml support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+
+tasks:
+  - init: make
+
+vscode:
+  extensions:
+    - ms-python.python

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <p align="center">Power automated communication that people like to receive.</p>
 </p>
 
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blueviolet?logo=gitpod)](https://gitpod.io/#https://github.com/customerio/customerio-python/)
 ![PyPI](https://img.shields.io/pypi/v/customerio)
 ![Software License](https://img.shields.io/github/license/customerio/customerio-python)
 [![Build status](https://github.com/customerio/customerio-python/actions/workflows/main.yml/badge.svg)](https://github.com/customerio/customerio-python/actions/workflows/main.yml)


### PR DESCRIPTION
This PR adds a `.gitpod.yml` config file and adds the "open in gitpod" badge to our README.

It won't require cutting a new release as there's nothing altered about the actual client library.