### PR TITLE
feat: add support for invite-type anonymous event tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ cio.track_anonymous(anonymous_id="anon-event", name="purchased", price=23.45, pr
 
 An anonymous event is an event associated with a person you haven't identified. The event requires an `anonymous_id` representing the unknown person and an event `name`. When you identify a person, you can set their `anonymous_id` attribute. If [event merging](https://customer.io/docs/anonymous-events/#turn-on-merging) is turned on in your workspace, and the attribute matches the `anonymous_id` in one or more events that were logged within the last 30 days, we associate those events with the person.
 
+#### Anonymous invite events
+
+If you previously sent [invite events](https://customer.io/docs/anonymous-invite-emails/), you can achieve the same functionality by sending an anonymous event with the anonymous identifier set to `None`. To send anonymous invites, your event *must* include a `recipient` attribute. 
+
+```python
+cio.track_anonymous(anonymous_id=None, name="invite", first_name="alex", recipient="alex.person@example.com")
+```
+
 ### Delete a customer profile
 ```python
 cio.delete(customer_id="5")

--- a/customerio/__version__.py
+++ b/customerio/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 4, 0, 'final', 0)
+VERSION = (1, 5, 0, 'final', 0)
 
 def get_version():
     version = '%s.%s' % (VERSION[0], VERSION[1])

--- a/customerio/track.py
+++ b/customerio/track.py
@@ -79,14 +79,14 @@ class CustomerIO(ClientBase):
 
     def track_anonymous(self, anonymous_id, name, **data):
         '''Track an event for a given anonymous_id'''
-        if not anonymous_id:
-            raise CustomerIOException("anonymous_id cannot be blank in track")
         url = self.get_events_query_string()
         post_data = {
-            'anonymous_id': anonymous_id,
             'name': name,
             'data': self._sanitize(data),
         }
+        if anonymous_id:
+            post_data['anonymous_id'] = anonymous_id
+        
         self.send_request('POST', url, post_data)
 
     def pageview(self, customer_id, page, **data):


### PR DESCRIPTION
Re-introduces support for anonymous event tracking using activity items unassociated with profiles by passing in a blank value for `anonymous_id`

**Usage:**

```python
track_anonymous(None, "my-event", foo="bar")
```