### PR TITLE
Transactional - amp_body prop to body_amp for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0]
+### Changed
+- Updated transactional email request optional argument `amp_body` to `body_amp` for consistency across APIs ([#93](https://github.com/customerio/customerio-python/pull/93))
+
 ## [1.6.1]
 ### Added
 - Added the `disable_css_preprocessing` and `language` optional fields to send request
@@ -16,7 +20,6 @@
 ### Added
 - Support for EU region
 
-### Removed
 ### Changed
 - `customerio.CustomerIO` and `customerio.APIClient`  have a new keyword parameter `region` that can be set to either `Regions.US` or `Regions.EU`
 

--- a/customerio/__version__.py
+++ b/customerio/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 6, 1, 'final', 0)
+VERSION = (2, 0, 0, 'final', 0)
 
 def get_version():
     version = '%s.%s' % (VERSION[0], VERSION[1])

--- a/customerio/api.py
+++ b/customerio/api.py
@@ -42,8 +42,8 @@ class SendEmailRequest(object):
             subject=None,
             preheader=None,
             body=None,
-            plaintext_body=None,
-            amp_body=None,
+            body_plaintext=None,
+            body_amp=None,
             fake_bcc=None,
             disable_message_retention=None,
             send_to_unsubscribed=None,
@@ -66,8 +66,8 @@ class SendEmailRequest(object):
         self.subject = subject
         self.preheader = preheader
         self.body = body
-        self.plaintext_body = plaintext_body
-        self.amp_body = amp_body
+        self.body_plaintext = body_plaintext
+        self.body_amp = body_amp
         self.fake_bcc = fake_bcc
         self.disable_message_retention = disable_message_retention
         self.send_to_unsubscribed = send_to_unsubscribed
@@ -111,8 +111,8 @@ class SendEmailRequest(object):
             subject="subject",
             preheader="preheader",
             body="body",
-            plaintext_body="plaintext_body",
-            amp_body="amp_body",
+            body_plaintext="body_plaintext",
+            body_amp="body_amp",
             fake_bcc="fake_bcc",
             disable_message_retention="disable_message_retention",
             send_to_unsubscribed="send_to_unsubscribed",

--- a/customerio/api.py
+++ b/customerio/api.py
@@ -42,7 +42,7 @@ class SendEmailRequest(object):
             subject=None,
             preheader=None,
             body=None,
-            body_plaintext=None,
+            body_plain=None,
             body_amp=None,
             fake_bcc=None,
             disable_message_retention=None,
@@ -66,7 +66,7 @@ class SendEmailRequest(object):
         self.subject = subject
         self.preheader = preheader
         self.body = body
-        self.body_plaintext = body_plaintext
+        self.body_plain = body_plain
         self.body_amp = body_amp
         self.fake_bcc = fake_bcc
         self.disable_message_retention = disable_message_retention
@@ -111,7 +111,7 @@ class SendEmailRequest(object):
             subject="subject",
             preheader="preheader",
             body="body",
-            body_plaintext="body_plaintext",
+            body_plain="body_plain",
             body_amp="body_amp",
             fake_bcc="fake_bcc",
             disable_message_retention="disable_message_retention",


### PR DESCRIPTION
Updating Transactional API endpoint properties `amp_body` `amp_plaintext` to `body_amp` `body_plaintext` to maintain consistency with Newsletters API.