### PR TITLE
clairfy transactional example with email

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ To use the [Transactional API](https://customer.io/docs/transactional-api), inst
 SendEmailRequest requires:
 * `transactional_message_id`: the ID of the transactional message you want to send, or the `body`, `from`, and `subject` of a new message.
 * `to`: the email address of your recipients 
-* an `identifiers` object containing the `id` of your recipient. If the `id` does not exist, Customer.io will create it.
+* an `identifiers` object containing the `email` and/or `id` of your recipient. If the person you reference by email or ID does not exist, Customer.io creates them.
 * a `message_data` object containing properties that you want reference in your message using Liquid.
 * You can also send attachments with your message. Use `attach` to encode attachments.
 
@@ -218,7 +218,7 @@ request = SendEmailRequest(
     ]
   },
   identifiers={
-    "id": "2",
+    "email": "person@example.com",
   }
 )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the `SendEmailRequest` example and requirements text; no runtime behavior is modified.
> 
> **Overview**
> Clarifies the transactional email docs in `README.md` by updating `SendEmailRequest` requirements to state that `identifiers` can include `email` and/or `id` (and that missing people are created).
> 
> Updates the example payload to use `identifiers={"email": "person@example.com"}` instead of an `id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c085d0a0a32e91298aa250e3354bfde1387b548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->