### PR TITLE
Support for event deduplication

### DIFF
--- a/customerio/track.py
+++ b/customerio/track.py
@@ -71,13 +71,14 @@ class CustomerIO(ClientBase):
         url = self.get_customer_query_string(id)
         self.send_request('PUT', url, kwargs)
 
-    def track(self, customer_id, name, **data):
+    def track(self, customer_id, name, id=None, **data):
         '''Track an event for a given customer_id'''
         if not customer_id:
             raise CustomerIOException("customer_id cannot be blank in track")
         url = self.get_event_query_string(customer_id)
         post_data = {
             'name': name,
+            'id': id,
             'data': self._sanitize(data),
         }
         self.send_request('POST', url, post_data)


### PR DESCRIPTION
Hi all! I noticed the current track event is not sending the id as part of the payload so the event deduplication feature is not working. 

This should do the fix, am I right? 

Can update formatting or attend any request from repository owners if this PR makes sense.

Thank you! 