### PR TITLE
fix: remove tests from distributed packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     license="BSD",
     description="Customer.io Python bindings.",
     url="https://github.com/customerio/customerio-python",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests",)),
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Solves https://github.com/customerio/customerio-python/issues/90

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk packaging-only change that alters what gets included in the built wheel/sdist. Main risk is inadvertently excluding non-test modules if they live under `tests` or rely on it at runtime.
> 
> **Overview**
> Updates `setup.py` to exclude the `tests` package from `find_packages`, preventing test code from being shipped in the distributed `customerio` package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a92be0b502d03b88c74885a40270e48e8862a11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->