### PR TITLE
Ensure POST methods get retried.

### DIFF
--- a/customerio/client_base.py
+++ b/customerio/client_base.py
@@ -101,7 +101,15 @@ Last caught exception -- {klass}: {message}
         # also define backoff_factor to delay each retry
         session.mount(
             'https://',
-            HTTPAdapter(max_retries=Retry(total=self.retries, backoff_factor=self.backoff_factor)))
+            HTTPAdapter(
+                max_retries=Retry(
+                    total=self.retries, 
+                    backoff_factor=self.backoff_factor,
+                    # Ensure POST methods get retries as well.
+                    allowed_methods=None
+                )
+            )
+        )
 
         return session
 


### PR DESCRIPTION
As per https://github.com/customerio/customerio-python/issues/76#issuecomment-1729378780 it appears that retries are, although advertised, completely broken at the moment.

This fix should ensure that HTTP POST methods use the retry configuration as well, which in turn makes `send_email()` be retried.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP retry behavior to include POST requests, which can increase duplicate writes/emails if upstream endpoints are not idempotent. Scope is small and isolated to session retry configuration.
> 
> **Overview**
> Updates the HTTP session retry configuration in `client_base.py` to retry *all* HTTP methods by setting `Retry.allowed_methods=None`, ensuring POST-based calls (e.g., email sends) respect the configured retry/backoff behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2543a712fe86d6a4740b25b38322f9294b45f7b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->