### PR TITLE
Fix potential AttributeError in session cleanup

### DIFF
--- a/customerio/client_base.py
+++ b/customerio/client_base.py
@@ -108,6 +108,6 @@ Last caught exception -- {klass}: {message}
     # closes the session if we're not using connection pooling.
     def _close(self):
         # if we're not using pooling; clean up the resources.
-        if (not self.use_connection_pooling):
+        if (not self.use_connection_pooling and self._current_session is not None):
             self._current_session.close()
             self._current_session = None


### PR DESCRIPTION
## Problem

```
File "customerio/client_base.py", line 112, in _close

...
AttributeError: 'NoneType' object has no attribute 'close'
```

The `_close()` method in `ClientBase` was attempting to call `.close()` on `self._current_session` without checking if it was `None` first. This could lead to an `AttributeError` when:

- Connection pooling is disabled (`use_connection_pooling=False`)
- The session hasn't been initialized yet or has been set to `None`

## Solution

Added a null check to the condition in `_close()` method to ensure we only attempt to close the session if it actually exists:

```python
# Before
if (not self.use_connection_pooling):
    self._current_session.close()  # Could raise AttributeError if None

# After  
if (not self.use_connection_pooling and self._current_session is not None):
    self._current_session.close()  # Safe - only called when session exists

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix that only changes cleanup behavior to avoid calling `.close()` on a `None` session when connection pooling is disabled.
> 
> **Overview**
> Prevents a potential `AttributeError` during request cleanup by updating `ClientBase._close()` to only close the session when connection pooling is disabled *and* `self._current_session` is not `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d40c54f57d0a8706957f970cf6d67db4f025b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->