### PR TITLE
Support transactional inbox messages

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -2,5 +2,5 @@ import warnings
 
 from customerio.client_base import CustomerIOException
 from customerio.track import CustomerIO
-from customerio.api import APIClient, SendEmailRequest, SendPushRequest, SendSMSRequest
+from customerio.api import APIClient, SendEmailRequest, SendPushRequest, SendSMSRequest, SendInboxMessageRequest
 from customerio.regions import Regions

--- a/customerio/api.py
+++ b/customerio/api.py
@@ -34,6 +34,12 @@ class APIClient(ClientBase):
         resp = self.send_request('POST', self.url + "/v1/send/sms", request)
         return json.loads(resp)
 
+    def send_inbox_message(self, request):
+        if isinstance(request, SendInboxMessageRequest):
+            request = request._to_dict()
+        resp = self.send_request('POST', self.url + "/v1/send/inbox_message", request)
+        return json.loads(resp)
+
     # builds the session.
     def _build_session(self):
         session = super()._build_session()
@@ -219,7 +225,7 @@ class SendPushRequest(object):
         return data
 
 class SendSMSRequest(object):
-    '''An object with all the options avaiable for triggering a transactional push message'''
+    '''An object with all the options avaiable for triggering a transactional SMS message'''
     def __init__(self,
             transactional_message_id=None,
             to=None,
@@ -251,6 +257,47 @@ class SendSMSRequest(object):
             identifiers="identifiers",
             disable_message_retention="disable_message_retention",
             send_to_unsubscribed="send_to_unsubscribed",
+            queue_draft="queue_draft",
+            message_data="message_data",
+            send_at="send_at",
+            language="language",
+        )
+
+        data = {}
+        for field, name in field_map.items():
+            value = getattr(self, field, None)
+            if value is not None:
+                data[name] = value
+
+        return data
+
+class SendInboxMessageRequest(object):
+    '''An object with all the options avaiable for triggering a transactional inbox message'''
+    def __init__(self,
+            transactional_message_id=None,
+            identifiers=None,
+            disable_message_retention=None,
+            queue_draft=None,
+            message_data=None,
+            send_at=None,
+            language=None,
+        ):
+
+        self.transactional_message_id = transactional_message_id
+        self.identifiers = identifiers
+        self.disable_message_retention = disable_message_retention
+        self.queue_draft = queue_draft
+        self.message_data = message_data
+        self.send_at = send_at
+        self.language = language
+
+    def _to_dict(self):
+        '''Build a request payload from the object'''
+        field_map = dict(
+            # field name is the same as the payload field name
+            transactional_message_id="transactional_message_id",
+            identifiers="identifiers",
+            disable_message_retention="disable_message_retention",
             queue_draft="queue_draft",
             message_data="message_data",
             send_at="send_at",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ import json
 import sys
 import unittest
 
-from customerio import APIClient, SendEmailRequest, SendPushRequest, SendSMSRequest, Regions, CustomerIOException
+from customerio import APIClient, SendEmailRequest, SendPushRequest, SendSMSRequest, SendInboxMessageRequest, Regions, CustomerIOException
 from customerio.__version__ import __version__ as ClientVersion
 from tests.server import HTTPSTestCase
 
@@ -111,5 +111,21 @@ class TestAPIClient(HTTPSTestCase):
 
         self.client.send_sms(sms)
 
+    def test_send_inbox_message(self):
+        self.client.http.hooks = dict(response=partial(self._check_request, rq={
+            'method': 'POST',
+            'authorization': "Bearer app_api_key",
+            'content_type': 'application/json',
+            'url_suffix': '/v1/send/inbox_message',
+            'body': {"identifiers": {"id":"customer_1"}, "transactional_message_id": 100}
+        }))
+
+        inbox_message = SendInboxMessageRequest(
+            identifiers={"id":"customer_1"},
+            transactional_message_id=100,
+        )
+
+        self.client.send_inbox_message(inbox_message)
+    
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new API wrapper method and request model plus test adjustments; limited surface area and no changes to existing request flows beyond test infrastructure headers/SSL settings.
> 
> **Overview**
> Adds support for sending **transactional inbox messages** via the App API by introducing `SendInboxMessageRequest` and a new `APIClient.send_inbox_message()` call that POSTs to `/v1/send/inbox_message`.
> 
> Updates exports/imports and extends the test suite with a new inbox-message request test; also hardens the HTTPS test server for newer SSL stacks by relaxing TLS verification/cipher requirements and sending explicit `Content-Length`/`Content-Type` headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0037d0cf9cde35d2a1d4fc3939647bd913f44bd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->