### PR TITLE
add support for sending transactional in-app messages

### DIFF
--- a/customerio/__init__.py
+++ b/customerio/__init__.py
@@ -2,5 +2,5 @@ import warnings
 
 from customerio.client_base import CustomerIOException
 from customerio.track import CustomerIO
-from customerio.api import APIClient, SendEmailRequest, SendPushRequest, SendSMSRequest, SendInboxMessageRequest
+from customerio.api import APIClient, SendEmailRequest, SendPushRequest, SendSMSRequest, SendInboxMessageRequest, SendInAppRequest
 from customerio.regions import Regions

--- a/customerio/api.py
+++ b/customerio/api.py
@@ -40,6 +40,12 @@ class APIClient(ClientBase):
         resp = self.send_request('POST', self.url + "/v1/send/inbox_message", request)
         return json.loads(resp)
 
+    def send_in_app(self, request):
+        if isinstance(request, SendInAppRequest):
+            request = request._to_dict()
+        resp = self.send_request('POST', self.url + "/v1/send/in_app", request)
+        return json.loads(resp)
+
     # builds the session.
     def _build_session(self):
         session = super()._build_session()
@@ -273,6 +279,47 @@ class SendSMSRequest(object):
 
 class SendInboxMessageRequest(object):
     '''An object with all the options avaiable for triggering a transactional inbox message'''
+    def __init__(self,
+            transactional_message_id=None,
+            identifiers=None,
+            disable_message_retention=None,
+            queue_draft=None,
+            message_data=None,
+            send_at=None,
+            language=None,
+        ):
+
+        self.transactional_message_id = transactional_message_id
+        self.identifiers = identifiers
+        self.disable_message_retention = disable_message_retention
+        self.queue_draft = queue_draft
+        self.message_data = message_data
+        self.send_at = send_at
+        self.language = language
+
+    def _to_dict(self):
+        '''Build a request payload from the object'''
+        field_map = dict(
+            # field name is the same as the payload field name
+            transactional_message_id="transactional_message_id",
+            identifiers="identifiers",
+            disable_message_retention="disable_message_retention",
+            queue_draft="queue_draft",
+            message_data="message_data",
+            send_at="send_at",
+            language="language",
+        )
+
+        data = {}
+        for field, name in field_map.items():
+            value = getattr(self, field, None)
+            if value is not None:
+                data[name] = value
+
+        return data
+
+class SendInAppRequest(object):
+    '''An object with all the options available for triggering a transactional in-app message'''
     def __init__(self,
             transactional_message_id=None,
             identifiers=None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ import json
 import sys
 import unittest
 
-from customerio import APIClient, SendEmailRequest, SendPushRequest, SendSMSRequest, SendInboxMessageRequest, Regions, CustomerIOException
+from customerio import APIClient, SendEmailRequest, SendPushRequest, SendSMSRequest, SendInboxMessageRequest, SendInAppRequest, Regions, CustomerIOException
 from customerio.__version__ import __version__ as ClientVersion
 from tests.server import HTTPSTestCase
 
@@ -126,6 +126,22 @@ class TestAPIClient(HTTPSTestCase):
         )
 
         self.client.send_inbox_message(inbox_message)
-    
+
+    def test_send_in_app(self):
+        self.client.http.hooks = dict(response=partial(self._check_request, rq={
+            'method': 'POST',
+            'authorization': "Bearer app_api_key",
+            'content_type': 'application/json',
+            'url_suffix': '/v1/send/in_app',
+            'body': {"identifiers": {"id":"customer_1"}, "transactional_message_id": 100}
+        }))
+
+        in_app = SendInAppRequest(
+            identifiers={"id":"customer_1"},
+            transactional_message_id=100,
+        )
+
+        self.client.send_in_app(in_app)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds `SendInAppRequest` and `APIClient.send_in_app()` for the `POST /v1/send/in_app` transactional API endpoint. Follows the same pattern as the existing inbox message support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new request type and a new API method following the existing transactional send patterns, with a focused unit test covering the request shape.
> 
> **Overview**
> Adds support for transactional in-app messages by introducing `SendInAppRequest` and `APIClient.send_in_app()` to call `POST /v1/send/in_app`.
> 
> Exports `SendInAppRequest` from `customerio/__init__.py` and extends `tests/test_api.py` with a new request/endpoint assertion for the in-app send flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6f86e096f7ecd0252f170f72733470b1c82376e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->