### PR TITLE
updates to makefile & ci configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: build
 
-on: [ push ]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ dev: clean all
 	$(PYTHON) -i -c "from customerio import *"
 
 upload:
-	python setup.py register
+	$(PYTHON) setup.py register
 	echo "*** Now upload the binary to PyPi *** (one second)" && sleep 3 && open dist & open "http://pypi.python.org/pypi?%3Aaction=pkg_edit&name=customerio" # python setup.py upload
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
+PYTHON ?= python3
 
 all:
-	python setup.py sdist
-	python -m doctest ./customerio/__init__.py
+	$(PYTHON) setup.py sdist
+	$(PYTHON) -m doctest ./customerio/__init__.py
 
 install:
-	python setup.py install
+	$(PYTHON) setup.py install
 
 clean:
-	python setup.py clean
+	$(PYTHON) setup.py clean
 	rm -rf MANIFEST build dist
 
 dev: clean all
 	if ! pip uninstall customerio; then echo "customerio not installed, installing it for the first time" ; fi
 	pip install dist/*
-	python -i -c "from customerio import *"
+	$(PYTHON) -i -c "from customerio import *"
 
 upload:
 	python setup.py register
@@ -21,4 +22,4 @@ upload:
 
 test:
 	openssl req -new -newkey rsa:2048 -days 10 -nodes -x509 -subj "/C=CA/ST=Ontario/L=Toronto/O=Test/CN=127.0.0.1" -keyout ./tests/server.pem -out ./tests/server.pem
-	python -m unittest discover -v
+	$(PYTHON) -m unittest discover -v


### PR DESCRIPTION
Ensure that our workflows run in the proper context & clean up the makefile to explicitly use `python3`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI trigger change and Makefile command normalization only; main impact is when tests run and which Python executable is used.
> 
> **Overview**
> Expands the GitHub Actions workflow triggers to run on `pull_request` and manual `workflow_dispatch` events (in addition to `push`).
> 
> Updates the `Makefile` to use a configurable `PYTHON` variable (defaulting to `python3`) for build, install, clean, dev, and test commands to avoid relying on `python` being present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9107693ec76144d0f43476483fb07aa025008a19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->