### PR TITLE
Fix disable CSS preprocessing spelling

### DIFF
--- a/customerio/api.py
+++ b/customerio/api.py
@@ -43,7 +43,7 @@ EMAIL_FIELD_MAP = COMMON_MESSAGE_FIELD_MAP | {
     "send_to_unsubscribed": "send_to_unsubscribed",
     "tracked": "tracked",
     "attachments": "attachments",
-    "disable_css_preproceessing": "disable_css_preproceessing",
+    "disable_css_preprocessing": "disable_css_preprocessing",
 }
 
 PUSH_FIELD_MAP = COMMON_MESSAGE_FIELD_MAP | {
@@ -152,10 +152,14 @@ class SendEmailRequest:
         queue_draft=None,
         message_data=None,
         attachments=None,
-        disable_css_preproceessing=None,
+        disable_css_preprocessing=None,
         send_at=None,
         language=None,
+        disable_css_preproceessing=None,
     ):
+        if disable_css_preprocessing is None:
+            disable_css_preprocessing = disable_css_preproceessing
+
         self.transactional_message_id = transactional_message_id
         self.to = to
         self.identifiers = identifiers
@@ -175,9 +179,17 @@ class SendEmailRequest:
         self.queue_draft = queue_draft
         self.message_data = message_data
         self.attachments = attachments
-        self.disable_css_preproceessing = disable_css_preproceessing
+        self.disable_css_preprocessing = disable_css_preprocessing
         self.send_at = send_at
         self.language = language
+
+    @property
+    def disable_css_preproceessing(self):
+        return self.disable_css_preprocessing
+
+    @disable_css_preproceessing.setter
+    def disable_css_preproceessing(self, value):
+        self.disable_css_preprocessing = value
 
     def attach(self, name, content, encode=True):
         """Helper method to add base64-encoded attachments."""

--- a/customerio/api.py
+++ b/customerio/api.py
@@ -155,11 +155,7 @@ class SendEmailRequest:
         disable_css_preprocessing=None,
         send_at=None,
         language=None,
-        disable_css_preproceessing=None,
     ):
-        if disable_css_preprocessing is None:
-            disable_css_preprocessing = disable_css_preproceessing
-
         self.transactional_message_id = transactional_message_id
         self.to = to
         self.identifiers = identifiers
@@ -182,14 +178,6 @@ class SendEmailRequest:
         self.disable_css_preprocessing = disable_css_preprocessing
         self.send_at = send_at
         self.language = language
-
-    @property
-    def disable_css_preproceessing(self):
-        return self.disable_css_preprocessing
-
-    @disable_css_preproceessing.setter
-    def disable_css_preproceessing(self, value):
-        self.disable_css_preprocessing = value
 
     def attach(self, name, content, encode=True):
         """Helper method to add base64-encoded attachments."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,6 +96,22 @@ class TestAPIClient(HTTPSTestCase):
 
         self.client.send_email(email)
 
+    def test_send_email_disable_css_preprocessing(self):
+        email = SendEmailRequest(disable_css_preprocessing=True)
+        payload = email._to_dict()
+
+        self.assertEqual(payload["disable_css_preprocessing"], True)
+        self.assertNotIn("disable_css_preproceessing", payload)
+
+    def test_send_email_disable_css_preprocessing_legacy_alias(self):
+        email = SendEmailRequest(disable_css_preproceessing=True)
+        email.disable_css_preproceessing = False
+        payload = email._to_dict()
+
+        self.assertEqual(email.disable_css_preprocessing, False)
+        self.assertEqual(payload["disable_css_preprocessing"], False)
+        self.assertNotIn("disable_css_preproceessing", payload)
+
     def test_send_push(self):
         self.client.http.hooks = dict(
             response=partial(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -103,14 +103,9 @@ class TestAPIClient(HTTPSTestCase):
         self.assertEqual(payload["disable_css_preprocessing"], True)
         self.assertNotIn("disable_css_preproceessing", payload)
 
-    def test_send_email_disable_css_preprocessing_legacy_alias(self):
-        email = SendEmailRequest(disable_css_preproceessing=True)
-        email.disable_css_preproceessing = False
-        payload = email._to_dict()
-
-        self.assertEqual(email.disable_css_preprocessing, False)
-        self.assertEqual(payload["disable_css_preprocessing"], False)
-        self.assertNotIn("disable_css_preproceessing", payload)
+    def test_send_email_disable_css_preprocessing_rejects_typo(self):
+        with self.assertRaises(TypeError):
+            SendEmailRequest(disable_css_preproceessing=True)
 
     def test_send_push(self):
         self.client.http.hooks = dict(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -96,17 +96,6 @@ class TestAPIClient(HTTPSTestCase):
 
         self.client.send_email(email)
 
-    def test_send_email_disable_css_preprocessing(self):
-        email = SendEmailRequest(disable_css_preprocessing=True)
-        payload = email._to_dict()
-
-        self.assertEqual(payload["disable_css_preprocessing"], True)
-        self.assertNotIn("disable_css_preproceessing", payload)
-
-    def test_send_email_disable_css_preprocessing_rejects_typo(self):
-        with self.assertRaises(TypeError):
-            SendEmailRequest(disable_css_preproceessing=True)
-
     def test_send_push(self):
         self.client.http.hooks = dict(
             response=partial(


### PR DESCRIPTION
## Summary
- Fix the transactional email field spelling to `disable_css_preprocessing`
- Remove the misspelled `disable_css_preproceessing` keyword and JSON field

## Tests
- `PYTHONPATH=/private/tmp/customerio-python-deps /Users/stephen/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m unittest discover -v`
