### PR TITLE
Fix retry logic for POST requests

### DIFF
--- a/customerio/client_base.py
+++ b/customerio/client_base.py
@@ -99,7 +99,6 @@ class ClientBase:
             backoff_factor=self.backoff_factor,
             allowed_methods=None,
             status_forcelist=[500, 502, 503, 504],
-            raise_on_status=False,
         )
         session.mount("https://", HTTPAdapter(max_retries=retry))
 

--- a/customerio/client_base.py
+++ b/customerio/client_base.py
@@ -52,17 +52,18 @@ class ClientBase:
                     )
 
             result_status = response.status_code
-            if result_status != 200:
+            if result_status < 200 or result_status >= 300:
                 raise CustomerIOException(f"{result_status}: {url} {data} {response.text}")
             return response.text
 
+        except CustomerIOException:
+            raise
         except Exception as e:
-            # Raise exception alerting user that the system might be
-            # experiencing an outage and refer them to system status page.
-            message = f"""Failed to receive valid response after {self.retries} retries.
-Check system status at http://status.customer.io.
-Last caught exception -- {type(e)}: {e}
-            """
+            message = (
+                f"Failed to receive valid response after {self.retries} retries.\n"
+                f"Check system status at http://status.customer.io.\n"
+                f"Last caught exception -- {type(e)}: {e}"
+            )
             raise CustomerIOException(message) from e
 
     def _sanitize(self, data):
@@ -93,9 +94,13 @@ Last caught exception -- {type(e)}: {e}
         session = Session()
         session.headers["User-Agent"] = f"Customer.io Python Client/{ClientVersion}"
 
-        session.mount(
-            "https://",
-            HTTPAdapter(max_retries=Retry(total=self.retries, backoff_factor=self.backoff_factor)),
+        retry = Retry(
+            total=self.retries,
+            backoff_factor=self.backoff_factor,
+            allowed_methods=None,
+            status_forcelist=[500, 502, 503, 504],
+            raise_on_status=False,
         )
+        session.mount("https://", HTTPAdapter(max_retries=retry))
 
         return session

--- a/tests/test_client_base.py
+++ b/tests/test_client_base.py
@@ -1,7 +1,7 @@
 import threading
 import unittest
 
-from customerio.client_base import ClientBase
+from customerio.client_base import ClientBase, CustomerIOException
 
 
 class FakeResponse:
@@ -81,6 +81,55 @@ class TestClientBase(unittest.TestCase):
         self.assertTrue(all(session.closed for session in sessions))
         self.assertTrue(all(session.request_count == 1 for session in sessions))
         self.assertIsNone(client._current_session)
+
+    def test_retry_config_allows_post(self):
+        client = ClientBase(retries=5, backoff_factor=0.1)
+        session = client._build_session()
+        adapter = session.get_adapter("https://example.com")
+        retry = adapter.max_retries
+
+        self.assertEqual(retry.total, 5)
+        self.assertEqual(retry.backoff_factor, 0.1)
+        self.assertIsNone(retry.allowed_methods)
+        self.assertEqual(set(retry.status_forcelist), {500, 502, 503, 504})
+
+    def test_non_200_raises_without_retry_wrapper(self):
+        client = ClientBase()
+
+        error_response = FakeResponse()
+        error_response.status_code = 400
+        error_response.text = "bad request"
+
+        def build_session():
+            session = FakeSession()
+            session.request = lambda *a, **kw: error_response
+            return session
+
+        client._build_session = build_session
+
+        with self.assertRaises(CustomerIOException) as ctx:
+            client.send_request("POST", "https://example.com", {})
+
+        self.assertIn("400", str(ctx.exception))
+        self.assertNotIn("retries", str(ctx.exception))
+
+    def test_2xx_status_codes_accepted(self):
+        client = ClientBase()
+
+        for status in [200, 201, 202, 204]:
+            response = FakeResponse()
+            response.status_code = status
+            response.text = "ok"
+
+            def build_session(resp=response):
+                session = FakeSession()
+                session.request = lambda *a, **kw: resp
+                return session
+
+            client._build_session = build_session
+            client._current_session = None
+            result = client.send_request("POST", "https://example.com", {})
+            self.assertEqual(result, "ok")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Enable retries for POST requests**: urllib3's `Retry` defaults exclude POST from `allowed_methods`, so all SDK retries were silently no-ops. Sets `allowed_methods=None` to retry all HTTP methods.
- **Retry on server errors**: Adds `status_forcelist=[500, 502, 503, 504]` so transient 5xx responses trigger retries.
- **Accept all 2xx status codes**: Previously only `200` was accepted; `201`, `202`, `204` etc. raised exceptions.
- **Fix misleading error wrapping**: 4xx errors from the API were caught by the generic `except Exception` and wrapped in "Failed after N retries" — now `CustomerIOException` is re-raised directly.

## Context
This is the most-reported issue in the repo ([#76](https://github.com/customerio/customerio-python/issues/76)), active since 2021 with users hitting `ConnectionResetError` in production. The root cause was [identified by @skion](https://github.com/customerio/customerio-python/issues/76#issuecomment-1729378780): retry parameters were decorative for POST.

Closes #76

## Test plan
- [x] `test_retry_config_allows_post` — verifies `allowed_methods=None` and `status_forcelist` on built session
- [x] `test_non_200_raises_without_retry_wrapper` — 400 errors raise clean `CustomerIOException` without "retries" noise
- [x] `test_2xx_status_codes_accepted` — 200/201/202/204 all pass through
- [x] Full test suite passes (`make test` — 31 tests)
- [x] Lint passes (`make lint`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP retry behavior and success-status handling for all client requests, which can affect error handling and timing in production; risk is mitigated by targeted unit tests.
> 
> **Overview**
> Fixes `ClientBase` request handling to treat any *2xx* response as success (instead of only `200`) and to re-raise `CustomerIOException` directly so API 4xx/validation errors aren’t wrapped as retry failures.
> 
> Updates the underlying `Retry` configuration to actually retry `POST` (and all methods) and to retry on transient 5xx responses via `status_forcelist`, with new unit tests validating the retry config and the updated status/exception behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ea47ee31b39bc2ab7faa4a3b47457ee4859afcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->