### PR TITLE
Add automated PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish.yml` — triggered on GitHub releases, builds wheel + sdist, publishes to PyPI via trusted publishing (OIDC)
- **#90 is already resolved** — the packaging modernization in #116 (`include = ["customerio*"]` + `MANIFEST.in prune tests`) already excludes `tests/` from both wheel and sdist. Verified by inspecting build artifacts.
- **#112 root cause**: no publish automation existed. Publishing was manual and only uploaded sdist.

## Setup required after merge
1. Create a `pypi` environment in GitHub repo settings
2. Configure [trusted publishing](https://docs.pypi.org/trusted-publishers/) on PyPI for `customerio/customerio-python` → `publish.yml` → `publish` job

Closes #112

## Test plan
- [x] `python -m build` produces both `.whl` and `.tar.gz`
- [x] Wheel contains only `customerio/` package (no `tests/`)
- [x] Sdist contains only `customerio/` package (no `tests/`)
- [x] Workflow YAML is valid (uses standard `pypa/gh-action-pypi-publish@release/v1`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automates artifact publishing to PyPI on GitHub Release events, so misconfiguration (e.g., trusted publishing/OIDC or Python version availability) could block releases or publish unintended builds.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/publish.yml`) that triggers on `release.published`, builds the package (`python -m build` for wheel + sdist), and publishes to PyPI using `pypa/gh-action-pypi-publish` with OIDC (`id-token: write`) in the `pypi` environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da689fd494e75a23813d7b061a0987dfd9b200c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->