### PR TITLE
Add context manager and close() to ClientBase

### DIFF
--- a/customerio/client_base.py
+++ b/customerio/client_base.py
@@ -24,6 +24,17 @@ class ClientBase:
         self.use_connection_pooling = use_connection_pooling
         self._current_session = None
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def close(self):
+        if self._current_session is not None:
+            self._current_session.close()
+            self._current_session = None
+
     @property
     def http(self):
         if self._current_session is None:

--- a/customerio/client_base.py
+++ b/customerio/client_base.py
@@ -32,8 +32,10 @@ class ClientBase:
 
     def close(self):
         if self._current_session is not None:
-            self._current_session.close()
-            self._current_session = None
+            try:
+                self._current_session.close()
+            finally:
+                self._current_session = None
 
     @property
     def http(self):

--- a/tests/test_client_base.py
+++ b/tests/test_client_base.py
@@ -134,6 +134,35 @@ class TestClientBase(unittest.TestCase):
             result = client.send_request("POST", "https://example.com", {})
             self.assertEqual(result.status_code, status)
 
+    def test_context_manager_closes_session(self):
+        client = ClientBase(use_connection_pooling=True)
+        session = FakeSession()
+        client._build_session = lambda: session
+
+        with client:
+            client.send_request("POST", "https://example.com", {})
+            self.assertFalse(session.closed)
+
+        self.assertTrue(session.closed)
+        self.assertIsNone(client._current_session)
+
+    def test_close_without_session(self):
+        client = ClientBase()
+        client.close()
+        self.assertIsNone(client._current_session)
+
+    def test_close_resets_session(self):
+        client = ClientBase(use_connection_pooling=True)
+        session = FakeSession()
+        client._build_session = lambda: session
+
+        client.send_request("POST", "https://example.com", {})
+        self.assertIsNotNone(client._current_session)
+
+        client.close()
+        self.assertTrue(session.closed)
+        self.assertIsNone(client._current_session)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_client_base.py
+++ b/tests/test_client_base.py
@@ -163,6 +163,17 @@ class TestClientBase(unittest.TestCase):
         self.assertTrue(session.closed)
         self.assertIsNone(client._current_session)
 
+    def test_close_resets_session_even_on_error(self):
+        client = ClientBase(use_connection_pooling=True)
+        session = FakeSession()
+        session.close = lambda: (_ for _ in ()).throw(RuntimeError("close failed"))
+        client._current_session = session
+
+        with self.assertRaises(RuntimeError):
+            client.close()
+
+        self.assertIsNone(client._current_session)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds `__enter__`, `__exit__`, and `close()` to `ClientBase`
- Both `CustomerIO` and `APIClient` inherit this, enabling:
  ```python
  with CustomerIO(site_id, api_key) as cio:
      cio.identify(id="123", name="Alice")
  # session is automatically closed, no ResourceWarning
  ```
- `close()` is also available standalone for non-context-manager usage

Closes #87

## Test plan
- [x] `test_context_manager_closes_session` — session closed on `__exit__`, `_current_session` reset
- [x] `test_close_without_session` — calling `close()` before any request is safe
- [x] `test_close_resets_session` — calling `close()` after requests cleans up properly
- [x] Full test suite passes (31 tests)
- [x] Lint passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive session-cleanup behavior with tests, and it only affects resource lifecycle when `close()`/context manager is used.
> 
> **Overview**
> `ClientBase` now supports `with`-statement usage via `__enter__`/`__exit__` and exposes a `close()` method to explicitly close and clear the internally pooled HTTP session.
> 
> Tests are added to verify sessions are closed on context exit, that `close()` is safe when no session exists, and that `_current_session` is cleared even if `session.close()` raises.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979dbea534f6b301c9d84654b266074635e8ae79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->