### PR TITLE
Return response objects from all client methods

### DIFF
--- a/customerio/api.py
+++ b/customerio/api.py
@@ -3,7 +3,6 @@ Implements the client that interacts with Customer.io's App API using app keys.
 """
 
 import base64
-import json
 
 from .client_base import ClientBase, CustomerIOException
 from .regions import Region, Regions
@@ -95,31 +94,31 @@ class APIClient(ClientBase):
         if isinstance(request, SendEmailRequest):
             request = request._to_dict()
         resp = self.send_request("POST", self.url + "/v1/send/email", request)
-        return json.loads(resp)
+        return resp.json()
 
     def send_push(self, request):
         if isinstance(request, SendPushRequest):
             request = request._to_dict()
         resp = self.send_request("POST", self.url + "/v1/send/push", request)
-        return json.loads(resp)
+        return resp.json()
 
     def send_sms(self, request):
         if isinstance(request, SendSMSRequest):
             request = request._to_dict()
         resp = self.send_request("POST", self.url + "/v1/send/sms", request)
-        return json.loads(resp)
+        return resp.json()
 
     def send_inbox_message(self, request):
         if isinstance(request, SendInboxMessageRequest):
             request = request._to_dict()
         resp = self.send_request("POST", self.url + "/v1/send/inbox_message", request)
-        return json.loads(resp)
+        return resp.json()
 
     def send_in_app(self, request):
         if isinstance(request, SendInAppRequest):
             request = request._to_dict()
         resp = self.send_request("POST", self.url + "/v1/send/in_app", request)
-        return json.loads(resp)
+        return resp.json()
 
     def _build_session(self):
         session = super()._build_session()

--- a/customerio/client_base.py
+++ b/customerio/client_base.py
@@ -54,7 +54,7 @@ class ClientBase:
             result_status = response.status_code
             if result_status < 200 or result_status >= 300:
                 raise CustomerIOException(f"{result_status}: {url} {data} {response.text}")
-            return response.text
+            return response
 
         except CustomerIOException:
             raise

--- a/customerio/track.py
+++ b/customerio/track.py
@@ -247,7 +247,7 @@ class CustomerIO(ClientBase):
             url = f"https://{self.host}/api/v2/batch"
         else:
             url = f"https://{self.host}:{self.port}/api/v2/batch"
-        self.send_request("POST", url, {"batch": operations})
+        return self.send_request("POST", url, {"batch": operations})
 
     def _build_session(self):
         session = super()._build_session()

--- a/customerio/track.py
+++ b/customerio/track.py
@@ -89,7 +89,7 @@ class CustomerIO(ClientBase):
         if not id:
             raise CustomerIOException("id cannot be blank in identify")
         url = self.get_customer_query_string(id)
-        self.send_request("PUT", url, kwargs)
+        return self.send_request("PUT", url, kwargs)
 
     def track(self, customer_id, name, **data):
         """Track an event for a given customer_id."""
@@ -100,7 +100,7 @@ class CustomerIO(ClientBase):
             "name": name,
             "data": self._sanitize(data),
         }
-        self.send_request("POST", url, post_data)
+        return self.send_request("POST", url, post_data)
 
     def track_anonymous(self, anonymous_id, name, **data):
         """Track an event for a given anonymous_id."""
@@ -112,7 +112,7 @@ class CustomerIO(ClientBase):
         if anonymous_id:
             post_data["anonymous_id"] = anonymous_id
 
-        self.send_request("POST", url, post_data)
+        return self.send_request("POST", url, post_data)
 
     def pageview(self, customer_id, page, **data):
         """Track a pageview for a given customer_id."""
@@ -124,7 +124,7 @@ class CustomerIO(ClientBase):
             "name": page,
             "data": self._sanitize(data),
         }
-        self.send_request("POST", url, post_data)
+        return self.send_request("POST", url, post_data)
 
     def backfill(self, customer_id, name, timestamp, **data):
         """Backfill an event (track with timestamp) for a given customer_id."""
@@ -147,7 +147,7 @@ class CustomerIO(ClientBase):
             "timestamp": timestamp,
         }
 
-        self.send_request("POST", url, post_data)
+        return self.send_request("POST", url, post_data)
 
     def delete(self, customer_id):
         """Delete a customer profile."""
@@ -155,7 +155,7 @@ class CustomerIO(ClientBase):
             raise CustomerIOException("customer_id cannot be blank in delete")
 
         url = self.get_customer_query_string(customer_id)
-        self.send_request("DELETE", url, {})
+        return self.send_request("DELETE", url, {})
 
     def add_device(self, customer_id, device_id, platform, **data):
         """Add a device to a customer profile."""
@@ -176,7 +176,7 @@ class CustomerIO(ClientBase):
         )
         payload = {"device": data}
         url = self.get_device_query_string(customer_id)
-        self.send_request("PUT", url, payload)
+        return self.send_request("PUT", url, payload)
 
     def delete_device(self, customer_id, device_id):
         """Delete a device from a customer profile."""
@@ -188,13 +188,13 @@ class CustomerIO(ClientBase):
 
         url = self.get_device_query_string(customer_id)
         delete_url = f"{url}/{self._url_encode(device_id)}"
-        self.send_request("DELETE", delete_url, {})
+        return self.send_request("DELETE", delete_url, {})
 
     def suppress(self, customer_id):
         if not customer_id:
             raise CustomerIOException("customer_id cannot be blank in suppress")
 
-        self.send_request(
+        return self.send_request(
             "POST",
             f"{self.base_url}/customers/{self._url_encode(customer_id)}/suppress",
             {},
@@ -204,7 +204,7 @@ class CustomerIO(ClientBase):
         if not customer_id:
             raise CustomerIOException("customer_id cannot be blank in unsuppress")
 
-        self.send_request(
+        return self.send_request(
             "POST",
             f"{self.base_url}/customers/{self._url_encode(customer_id)}/unsuppress",
             {},
@@ -232,7 +232,7 @@ class CustomerIO(ClientBase):
             "primary": {primary_id_type: primary_id},
             "secondary": {secondary_id_type: secondary_id},
         }
-        self.send_request("POST", url, post_data)
+        return self.send_request("POST", url, post_data)
 
     def batch(self, operations):
         """Send multiple operations in a single request.

--- a/tests/test_client_base.py
+++ b/tests/test_client_base.py
@@ -43,8 +43,10 @@ class TestClientBase(unittest.TestCase):
 
         client._build_session = build_session
 
-        self.assertEqual(client.send_request("POST", "https://example.com", {}), "ok")
-        self.assertEqual(client.send_request("POST", "https://example.com", {}), "ok")
+        resp1 = client.send_request("POST", "https://example.com", {})
+        resp2 = client.send_request("POST", "https://example.com", {})
+        self.assertEqual(resp1.status_code, 200)
+        self.assertEqual(resp2.status_code, 200)
 
         self.assertEqual(len(sessions), 1)
         self.assertFalse(sessions[0].closed)
@@ -76,7 +78,8 @@ class TestClientBase(unittest.TestCase):
             thread.join()
 
         self.assertEqual(errors, [])
-        self.assertEqual(sorted(responses), ["ok", "ok"])
+        self.assertEqual(len(responses), 2)
+        self.assertTrue(all(r.status_code == 200 for r in responses))
         self.assertEqual(len(sessions), 2)
         self.assertTrue(all(session.closed for session in sessions))
         self.assertTrue(all(session.request_count == 1 for session in sessions))

--- a/tests/test_client_base.py
+++ b/tests/test_client_base.py
@@ -132,7 +132,7 @@ class TestClientBase(unittest.TestCase):
             client._build_session = build_session
             client._current_session = None
             result = client.send_request("POST", "https://example.com", {})
-            self.assertEqual(result, "ok")
+            self.assertEqual(result.status_code, status)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **`send_request()`** now returns the `requests.Response` object instead of `response.text`
- **Track API methods** (`identify`, `track`, `pageview`, `backfill`, `delete`, `add_device`, `delete_device`, `suppress`, `unsuppress`, `merge_customers`) now return the response instead of `None`
- **APIClient methods** (`send_email`, `send_push`, etc.) continue to return parsed JSON dicts — switched from `json.loads(resp)` to `resp.json()`

### Breaking change
Track API methods previously returned `None`. Code that checked `result is None` or relied on the falsy return will need updating. However, the most common usage pattern (`cio.identify(...)` without capturing return) is unaffected.

### Example
```python
# Before: no way to inspect the response
cio.identify(id="123", name="Alice")

# After: response available if needed
resp = cio.identify(id="123", name="Alice")
print(resp.status_code)  # 200
```

Closes #85

## Test plan
- [x] Updated `test_client_base.py` assertions for Response objects
- [x] All existing Track API tests pass (use hooks, don't assert return values)
- [x] All existing APIClient tests pass (return value contract unchanged — still dicts)
- [x] Full test suite passes (28 tests)
- [x] Lint passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a small but **behavior-changing** API shift: `send_request` and all Track API calls now return `requests.Response`, which may break callers that assumed `None`/string returns or compared return values directly. Core request/response handling is touched, but logic changes are straightforward and covered by updated tests.
> 
> **Overview**
> Updates the core HTTP layer so `ClientBase.send_request()` returns the full `requests.Response` object (instead of `response.text`).
> 
> Propagates this through the Track client so methods like `identify`, `track`, `delete`, `merge_customers`, and `batch` now return the response rather than `None`, enabling callers to inspect status codes/headers.
> 
> Keeps `APIClient` return values as parsed JSON dicts, but switches parsing to `resp.json()` and removes the now-unused `json` import. Tests are updated to assert on `Response` attributes (e.g., `status_code`) instead of raw strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b07b6602adbd2615c2ca0b7e2836627563a7b7f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->