### PR TITLE
Add batch() method to CustomerIO track client

### DIFF
--- a/customerio/track.py
+++ b/customerio/track.py
@@ -243,7 +243,10 @@ class CustomerIO(ClientBase):
         if not operations:
             raise CustomerIOException("operations cannot be empty in batch")
 
-        url = self.base_url.replace("/api/v1", "/api/v2/batch")
+        if self.port == 443:
+            url = f"https://{self.host}/api/v2/batch"
+        else:
+            url = f"https://{self.host}:{self.port}/api/v2/batch"
         self.send_request("POST", url, {"batch": operations})
 
     def _build_session(self):

--- a/customerio/track.py
+++ b/customerio/track.py
@@ -234,6 +234,18 @@ class CustomerIO(ClientBase):
         }
         self.send_request("POST", url, post_data)
 
+    def batch(self, operations):
+        """Send multiple operations in a single request.
+
+        Each operation is a dict with at minimum 'type' and 'action' keys.
+        See https://customer.io/docs/api/track/#operation/batch
+        """
+        if not operations:
+            raise CustomerIOException("operations cannot be empty in batch")
+
+        url = self.base_url.replace("/api/v1", "/api/v2/batch")
+        self.send_request("POST", url, {"batch": operations})
+
     def _build_session(self):
         session = super()._build_session()
         session.auth = (self.site_id, self.api_key)

--- a/tests/test_customerio.py
+++ b/tests/test_customerio.py
@@ -469,6 +469,58 @@ class TestCustomerIO(HTTPSTestCase):
                 secondary_id="",
             )
 
+    def test_batch_call(self):
+        self.cio.http.hooks = dict(
+            response=partial(
+                self._check_request,
+                rq={
+                    "method": "POST",
+                    "authorization": _basic_auth_str("siteid", "apikey"),
+                    "content_type": "application/json",
+                    "url_suffix": "/api/v2/batch",
+                    "body": {
+                        "batch": [
+                            {
+                                "type": "person",
+                                "action": "identify",
+                                "identifiers": {"id": "1"},
+                                "attributes": {"name": "Alice"},
+                            },
+                            {
+                                "type": "person",
+                                "action": "event",
+                                "identifiers": {"id": "1"},
+                                "name": "purchase",
+                            },
+                        ]
+                    },
+                },
+            )
+        )
+
+        self.cio.batch(
+            [
+                {
+                    "type": "person",
+                    "action": "identify",
+                    "identifiers": {"id": "1"},
+                    "attributes": {"name": "Alice"},
+                },
+                {
+                    "type": "person",
+                    "action": "event",
+                    "identifiers": {"id": "1"},
+                    "name": "purchase",
+                },
+            ]
+        )
+
+        with self.assertRaises(CustomerIOException):
+            self.cio.batch([])
+
+        with self.assertRaises(CustomerIOException):
+            self.cio.batch(None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds `batch()` method to `CustomerIO` class wrapping `POST /api/v2/batch`
- Accepts a list of operation dicts, each with `type`, `action`, `identifiers`, and action-specific fields
- Validates that operations list is non-empty

### Example
```python
cio.batch([
    {
        "type": "person",
        "action": "identify",
        "identifiers": {"id": "1"},
        "attributes": {"name": "Alice"},
    },
    {
        "type": "person",
        "action": "event",
        "identifiers": {"id": "1"},
        "name": "purchase",
    },
])
```

Closes #96

## Test plan
- [x] `test_batch_call` — verifies correct URL (`/api/v2/batch`), method (POST), auth, content-type, and body structure
- [x] Empty/None operations raises `CustomerIOException`
- [x] Full test suite passes (29 tests)
- [x] Lint passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new client method and corresponding unit test without altering existing request flows; main risk is incorrect endpoint/URL construction for non-default ports.
> 
> **Overview**
> Adds a new `CustomerIO.batch(operations)` helper that posts a list of Track API v2 operations to `POST /api/v2/batch`, with a guard that rejects empty/`None` operation lists.
> 
> Introduces `test_batch_call` to assert the request method, auth header, content type, URL suffix, and payload shape, and to verify invalid inputs raise `CustomerIOException`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec6ce45c923c9828d44d2092c211089dc9ea618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->