### PR TITLE
Fix timezone-aware datetime conversion

### DIFF
--- a/customerio/client_base.py
+++ b/customerio/client_base.py
@@ -123,6 +123,8 @@ class ClientBase:
         return value
 
     def _datetime_to_timestamp(self, dt):
+        if dt.tzinfo is not None:
+            return int(dt.astimezone(timezone.utc).timestamp())
         return int(dt.replace(tzinfo=timezone.utc).timestamp())
 
     def _stringify_list(self, customer_ids):

--- a/tests/test_customerio.py
+++ b/tests/test_customerio.py
@@ -572,12 +572,6 @@ class TestCustomerIO(HTTPSTestCase):
         data_out = self.cio._sanitize(data_in)
         self.assertEqual(data_out, dict(dt=1234567890))
 
-    def test_sanitize_aware_utc_datetime(self):
-        """Tz-aware UTC datetimes produce the correct timestamp."""
-        data_in = dict(dt=datetime(2009, 2, 13, 23, 31, 30, 0, timezone.utc))
-        data_out = self.cio._sanitize(data_in)
-        self.assertEqual(data_out, dict(dt=1234567890))
-
     def test_sanitize_aware_non_utc_datetime(self):
         """Tz-aware non-UTC datetimes are converted, not silently replaced."""
         # 2009-02-13 18:31:30 at UTC-5 is 2009-02-13 23:31:30 UTC

--- a/tests/test_customerio.py
+++ b/tests/test_customerio.py
@@ -1,7 +1,7 @@
 import json
 import socket
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from functools import partial
 
 import urllib3
@@ -562,9 +562,27 @@ class TestCustomerIO(HTTPSTestCase):
             self.cio.unsuppress(None)
 
     def test_sanitize(self):
-        from datetime import timezone
-
         data_in = dict(dt=datetime(2009, 2, 13, 23, 31, 30, 0, timezone.utc))
+        data_out = self.cio._sanitize(data_in)
+        self.assertEqual(data_out, dict(dt=1234567890))
+
+    def test_sanitize_naive_datetime(self):
+        """Naive datetimes are assumed UTC (backward compatible)."""
+        data_in = dict(dt=datetime(2009, 2, 13, 23, 31, 30))
+        data_out = self.cio._sanitize(data_in)
+        self.assertEqual(data_out, dict(dt=1234567890))
+
+    def test_sanitize_aware_utc_datetime(self):
+        """Tz-aware UTC datetimes produce the correct timestamp."""
+        data_in = dict(dt=datetime(2009, 2, 13, 23, 31, 30, 0, timezone.utc))
+        data_out = self.cio._sanitize(data_in)
+        self.assertEqual(data_out, dict(dt=1234567890))
+
+    def test_sanitize_aware_non_utc_datetime(self):
+        """Tz-aware non-UTC datetimes are converted, not silently replaced."""
+        # 2009-02-13 18:31:30 at UTC-5 is 2009-02-13 23:31:30 UTC
+        tz_minus_5 = timezone(timedelta(hours=-5))
+        data_in = dict(dt=datetime(2009, 2, 13, 18, 31, 30, 0, tz_minus_5))
         data_out = self.cio._sanitize(data_in)
         self.assertEqual(data_out, dict(dt=1234567890))
 


### PR DESCRIPTION
## Summary
- `_datetime_to_timestamp()` used `dt.replace(tzinfo=timezone.utc)` which silently discards existing timezone info instead of converting — a datetime at UTC-5 would be treated as UTC, producing the wrong timestamp
- Now uses `dt.astimezone(timezone.utc)` for tz-aware datetimes, preserving `dt.replace()` only for naive datetimes (backward compatible)
- 3 new tests covering naive, tz-aware UTC, and tz-aware non-UTC datetimes

## Test plan
- [x] Naive datetime produces same result as before (backward compat)
- [x] Tz-aware UTC datetime produces correct timestamp
- [x] Tz-aware non-UTC datetime (UTC-5) correctly converts
- [x] All 51 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how timestamps are generated for tz-aware `datetime` values, which can alter event/customer data sent to the API for non-UTC inputs. Scope is small and covered by added unit tests, but impacts payload correctness.
> 
> **Overview**
> Fixes datetime sanitization so **timezone-aware** `datetime` values are *converted* to UTC before timestamping (using `astimezone(timezone.utc)`) instead of silently overriding their timezone via `replace()`.
> 
> Keeps prior behavior for **naive** datetimes (assumed UTC) and adds tests for naive, UTC-aware, and non-UTC-aware datetime inputs to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7fd1cc6ca7fca62419edba036d98b05da2695e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->