### PR TITLE
Fix falsy ID validation rejecting id=0

### DIFF
--- a/customerio/track.py
+++ b/customerio/track.py
@@ -86,14 +86,14 @@ class CustomerIO(ClientBase):
 
     def identify(self, id, **kwargs):
         """Identify a single customer by their unique id, and optionally add attributes."""
-        if not id:
+        if id is None or id == "":
             raise CustomerIOException("id cannot be blank in identify")
         url = self.get_customer_query_string(id)
         return self.send_request("PUT", url, kwargs)
 
     def track(self, customer_id, name, data=None, id=None, timestamp=None):
         """Track an event for a given customer_id."""
-        if not customer_id:
+        if customer_id is None or customer_id == "":
             raise CustomerIOException("customer_id cannot be blank in track")
         url = self.get_event_query_string(customer_id)
         post_data = self._build_event(name, data, id=id, timestamp=timestamp)
@@ -103,14 +103,14 @@ class CustomerIO(ClientBase):
         """Track an event for a given anonymous_id."""
         url = self.get_events_query_string()
         post_data = self._build_event(name, data, id=id, timestamp=timestamp)
-        if anonymous_id:
+        if anonymous_id is not None and anonymous_id != "":
             post_data["anonymous_id"] = anonymous_id
 
         return self.send_request("POST", url, post_data)
 
     def pageview(self, customer_id, page, **data):
         """Track a pageview for a given customer_id."""
-        if not customer_id:
+        if customer_id is None or customer_id == "":
             raise CustomerIOException("customer_id cannot be blank in pageview")
         url = self.get_event_query_string(customer_id)
         post_data = {
@@ -122,7 +122,7 @@ class CustomerIO(ClientBase):
 
     def backfill(self, customer_id, name, timestamp, **data):
         """Backfill an event (track with timestamp) for a given customer_id."""
-        if not customer_id:
+        if customer_id is None or customer_id == "":
             raise CustomerIOException("customer_id cannot be blank in backfill")
 
         url = self.get_event_query_string(customer_id)
@@ -166,7 +166,7 @@ class CustomerIO(ClientBase):
 
     def delete(self, customer_id):
         """Delete a customer profile."""
-        if not customer_id:
+        if customer_id is None or customer_id == "":
             raise CustomerIOException("customer_id cannot be blank in delete")
 
         url = self.get_customer_query_string(customer_id)
@@ -174,13 +174,13 @@ class CustomerIO(ClientBase):
 
     def add_device(self, customer_id, device_id, platform, **data):
         """Add a device to a customer profile."""
-        if not customer_id:
+        if customer_id is None or customer_id == "":
             raise CustomerIOException("customer_id cannot be blank in add_device")
 
-        if not device_id:
+        if device_id is None or device_id == "":
             raise CustomerIOException("device_id cannot be blank in add_device")
 
-        if not platform:
+        if platform is None or platform == "":
             raise CustomerIOException("platform cannot be blank in add_device")
 
         data.update(
@@ -195,10 +195,10 @@ class CustomerIO(ClientBase):
 
     def delete_device(self, customer_id, device_id):
         """Delete a device from a customer profile."""
-        if not customer_id:
+        if customer_id is None or customer_id == "":
             raise CustomerIOException("customer_id cannot be blank in delete_device")
 
-        if not device_id:
+        if device_id is None or device_id == "":
             raise CustomerIOException("device_id cannot be blank in delete_device")
 
         url = self.get_device_query_string(customer_id)
@@ -206,7 +206,7 @@ class CustomerIO(ClientBase):
         return self.send_request("DELETE", delete_url, {})
 
     def suppress(self, customer_id):
-        if not customer_id:
+        if customer_id is None or customer_id == "":
             raise CustomerIOException("customer_id cannot be blank in suppress")
 
         return self.send_request(
@@ -216,7 +216,7 @@ class CustomerIO(ClientBase):
         )
 
     def unsuppress(self, customer_id):
-        if not customer_id:
+        if customer_id is None or customer_id == "":
             raise CustomerIOException("customer_id cannot be blank in unsuppress")
 
         return self.send_request(
@@ -236,10 +236,10 @@ class CustomerIO(ClientBase):
         if not self.is_valid_id_type(secondary_id_type):
             raise CustomerIOException("invalid secondary id type")
 
-        if not primary_id:
+        if primary_id is None or primary_id == "":
             raise CustomerIOException("primary customer_id cannot be blank")
 
-        if not secondary_id:
+        if secondary_id is None or secondary_id == "":
             raise CustomerIOException("secondary customer_id cannot be blank")
 
         url = f"{self.base_url}/merge_customers"

--- a/tests/test_customerio.py
+++ b/tests/test_customerio.py
@@ -672,6 +672,56 @@ class TestCustomerIO(HTTPSTestCase):
                 secondary_id="",
             )
 
+    def test_identify_with_zero_id(self):
+        self.cio.http.hooks = dict(
+            response=partial(
+                self._check_request,
+                rq={
+                    "method": "PUT",
+                    "url_suffix": "/customers/0",
+                    "body": {"name": "john"},
+                },
+            )
+        )
+
+        self.cio.identify(id=0, name="john")
+
+    def test_track_with_zero_customer_id(self):
+        self.cio.http.hooks = dict(
+            response=partial(
+                self._check_request,
+                rq={
+                    "method": "POST",
+                    "url_suffix": "/customers/0/events",
+                    "body": {"data": {}, "name": "login"},
+                },
+            )
+        )
+
+        self.cio.track(customer_id=0, name="login")
+
+    def test_identify_with_none_raises(self):
+        with self.assertRaises(CustomerIOException):
+            self.cio.identify(id=None, name="john")
+
+    def test_identify_with_empty_string_raises(self):
+        with self.assertRaises(CustomerIOException):
+            self.cio.identify(id="", name="john")
+
+    def test_delete_with_zero_customer_id(self):
+        self.cio.http.hooks = dict(
+            response=partial(
+                self._check_request,
+                rq={
+                    "method": "DELETE",
+                    "url_suffix": "/customers/0",
+                    "body": {},
+                },
+            )
+        )
+
+        self.cio.delete(customer_id=0)
+
     def test_batch_call(self):
         self.cio.http.hooks = dict(
             response=partial(


### PR DESCRIPTION
## Summary
- All ID validation guards used `if not val:` which rejects falsy-but-valid values like integer `0` (since `not 0` is `True`)
- Replaced 13 guards across `identify`, `track`, `backfill`, `pageview`, `delete`, `add_device`, `delete_device`, `suppress`, `unsuppress`, and `merge_customers` with `if val is None or val == "":` 
- Fixed `track_anonymous` inclusion guard similarly
- 5 new tests verifying `id=0` succeeds and `None`/`""` still raise

## Test plan
- [x] `identify(id=0)` succeeds, hits `/customers/0`
- [x] `track(customer_id=0)` succeeds, hits `/customers/0/events`
- [x] `delete(customer_id=0)` succeeds, hits `/customers/0`
- [x] `identify(id=None)` still raises `CustomerIOException`
- [x] `identify(id="")` still raises `CustomerIOException`
- [x] All 38 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow input-validation change to treat only `None`/empty string as blank, plus targeted tests; behavior changes only for previously-rejected falsy values like `0`.
> 
> **Overview**
> Fixes Track client validation so ID fields no longer reject falsy-but-valid values like integer `0`.
> 
> Replaces `if not ...` guards with explicit `is None or == ""` checks across customer/event/device APIs (`identify`, `track`, `pageview`, `backfill`, `delete`, `add_device`, `delete_device`, `suppress`, `unsuppress`, `merge_customers`) and updates `track_anonymous` to only omit `anonymous_id` when it’s `None`/empty.
> 
> Adds tests ensuring `id/customer_id=0` is accepted (and hits `/customers/0...`) while `None` and `""` still raise `CustomerIOException`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87dccd1078b0dcb5d93c4eea91aff6853501d40c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->